### PR TITLE
Fixed regular expression for package name validation

### DIFF
--- a/data-package.json
+++ b/data-package.json
@@ -6,7 +6,7 @@
     "properties": {
         "name": {
             "type": "string",
-            "pattern": "^([a-z\\.\\_\\-])+$"
+            "pattern": "^([a-z0-9\\.\\_\\-])+$"
         },
         "licences": {
             "type": "array",


### PR DESCRIPTION
The package specification says that a package name must be lower-case
and contain only alphanumeric characters along with the . , - or _
characters.  The previous regular expression did not allow for numeric
characters.

Issue: okfn/data.okfn.org#125
