### PR TITLE
Additions to comply with current state of JSON Table Schema spec

### DIFF
--- a/json-table-schema.json
+++ b/json-table-schema.json
@@ -54,6 +54,33 @@
                 },
                 "required": ["name"]
             }
+        },
+        "primaryKey": {
+            "enum": ["string", "array"]
+        },
+        "foreignKeys": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["fields", "reference"],
+                "properties": {
+                    "fields": {
+                        "enum": ["string", "array"]
+                    },
+                    "reference": {
+                        "type": "object",
+                        "required": ["resource", "fields"],
+                        "properties": {
+                            "resource": {
+                                "type": "string"
+                            },
+                            "fields": {
+                                "enum": ["string", "array"]
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "required": ["fields"]


### PR DESCRIPTION
This pull request adds `field.constraints`, `primaryKey` and `foreignKeys` in line with the spec.

There are two remaining issues in order to be fully compliant, but as far as I see they are not possible to express in JSON Schema v4 ([See the thread on the JSON Schema forum here](https://groups.google.com/forum/#!topic/json-schema/2Q_fC1SsC3M)):
- `field.constraints.minimum` and `field.constraints.maximum` should have a type that is _dependant_ on the type of the field. Currently has enum.
- Likewise, `foreignKey.reference.fields` should have the same type as `foreignKey.fields`, and is currently enum

I'm not sure what effect these changes have on other packages that depend on this schema, so consider this pull request a point of discussion. I'm working with my forked version now and will update the pull request if I come up with any issues.
