### PR TITLE
Allow hash value to be prefixed with the algorithm

### DIFF
--- a/data-package.json
+++ b/data-package.json
@@ -155,7 +155,7 @@
                     },
                     "hash": {
                         "type": "string",
-                        "pattern": "^([a-fA-F0-9]{32})$"
+                        "pattern": "^([^:]+:[a-fA-F0-9]+|[a-fA-F0-9]{32})$"
                     },
                     "modified": {
                         "type": "string"


### PR DESCRIPTION
I've left the original regex intact on the right hand side of the group, so that the validation of non-prefixed hashes is still strict.

Prefixed hashes are only considered valid if they consist of one or more non-colon characters followed by a colon and then a series of hexadecimal digits.

So, `sha1:8843d7f92416211de9ebb963ff4ce28125932878` is valid, but `foo:`, `:abc`, and `f:o:o:123` aren't.