### PR TITLE
feature/data-package-update-and-metadata

### DIFF
--- a/data-package.json
+++ b/data-package.json
@@ -8,6 +8,12 @@
       "type": "string",
       "pattern": "^([a-z0-9\\.\\_\\-])+$"
     },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
     "licences": {
       "type": "array",
       "items": {
@@ -21,12 +27,6 @@
           { "title": "url required", "required": ["url"] }
         ]
       }
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "type": "string"
     },
     "homepage": {
       "type": "string"
@@ -60,6 +60,9 @@
       "type": "string"
     },
     "image": {
+      "type": "string"
+    },
+    "base": {
       "type": "string"
     },
     "author": {

--- a/data-package.json
+++ b/data-package.json
@@ -7,31 +7,38 @@
     "name": {
       "type": "string",
       "title": "Name",
+      "description": "A lower-case string with only alphanumeric characters along with '.', '_' or '-' characters.",
       "pattern": "^([a-z0-9\\.\\_\\-])+$",
       "propertyOrder": 10
     },
     "title": {
       "title": "Title",
+      "description": "A human-readable title for this package.",
       "type": "string",
       "propertyOrder": 20
     },
     "description": {
       "title": "Description",
+      "description": "A text description of the package.",
       "type": "string",
-      "propertyOrder": 30
+      "propertyOrder": 30,
+      "format": "textarea"
     },
     "homepage": {
       "title": "Home Page",
+      "description": "The URL for this data package's website.",
       "type": "string",
       "propertyOrder": 40
     },
     "version": {
       "title": "Version",
+      "description": "A semantic versioning string for this package.",
       "type": "string",
       "propertyOrder": 50
     },
     "licences": {
       "title": "Licenses",
+      "description": "The license(s) under which this package is published.",
       "type": "array",
       "propertyOrder": 60,
       "items": {
@@ -48,11 +55,13 @@
     },
     "author": {
       "title": "Author",
+      "description": "The main contributor to this package.",
       "type": "string",
       "propertyOrder": 70
     },
     "contributors": {
       "title": "Contributors",
+      "description": "The contributors to this package.",
       "type": "array",
       "propertyOrder": 80,
       "items": {
@@ -73,57 +82,80 @@
     },
     "resources": {
       "title": "Resources",
+      "description": "The data resources that this package describes.",
       "type": "array",
       "propertyOrder": 90,
       "minItems": 0,
       "items": {
         "type": "object",
         "properties": {
+          "name": {
+            "title": "Name",
+            "description": "A lower-case string with only alphanumeric characters along with '.', '_' or '-' characters.",
+            "type": "string",
+            "propertyOrder": 10
+          },
           "url": {
             "title": "URL",
-            "type": "string"
+            "description": "The URL for this resource.",
+            "type": "string",
+            "propertyOrder": 20
           },
           "path": {
             "title": "Path",
-            "type": "string"
-          },
-          "name": {
-            "title": "Name",
-            "type": "string"
+            "description": "The relative path to this resource.",
+            "type": "string",
+            "propertyOrder": 30
           },
           "format": {
             "title": "Format",
-            "type": "string"
+            "description": "The file format of this resource.",
+            "type": "string",
+            "propertyOrder": 40
           },
           "mediatype": {
             "title": "Media Type",
+            "description": "The media type of this resource.",
             "type": "string",
+            "propertyOrder": 50,
             "pattern": "^(.+)/(.+)$"
           },
           "encoding": {
             "title": "Encoding",
-            "type": "string"
+            "description": "The file encoding of this resource.",
+            "type": "string",
+            "propertyOrder": 60
           },
           "bytes": {
             "title": "Bytes",
-            "type": "integer"
+            "description": "The size of this resource in bytes.",
+            "type": "integer",
+            "propertyOrder": 70
           },
           "hash": {
             "title": "Hash",
             "type": "string",
+            "description": "The MD5 hash of this resource. Other hash algorithms can be used by prefxing the hash value with the algorithm name in lowercase, followed by a colon.",
+            "propertyOrder": 80,
             "pattern": "^([^:]+:[a-fA-F0-9]+|[a-fA-F0-9]{32})$"
           },
           "schema": {
             "title": "Schema",
-            "type": "object"
+            "description": "The schema of this resource.",
+            "type": "object",
+            "propertyOrder": 90
           },
           "dialect": {
             "title": "Dialect",
-            "type": "object"
+            "description": "The dialect of this resource file type.",
+            "type": "object",
+            "propertyOrder": 100
           },
           "sources": {
             "title": "Sources",
+            "description": "The raw sources for this resource.",
             "type": "array",
+            "propertyOrder": 110,
             "items": {
               "type": "object",
               "properties": {
@@ -140,7 +172,9 @@
           },
           "licences": {
             "title": "Licenses",
+            "description": "The license(s) under which this resource is released.",
             "type": "array",
+            "propertyOrder": 120,
             "items": {
               "type": "object",
               "properties": {
@@ -162,6 +196,7 @@
     },
     "keywords": {
       "title": "Keywords",
+      "description": "A list of keywords that describe this package.",
       "type": "array",
       "propertyOrder": 100,
       "items": {
@@ -170,6 +205,7 @@
     },
     "sources": {
       "title": "Sources",
+      "description": "The raw sources for this package.",
       "type": "array",
       "propertyOrder": 110,
       "items": {
@@ -188,16 +224,19 @@
     },
     "image": {
       "title": "Image",
+      "description": "A image to represent this package.",
       "type": "string",
       "propertyOrder": 120
     },
     "base": {
       "title": "Base",
+      "description": "A base URI used to resolve resources that specify relative paths.",
       "type": "string",
       "propertyOrder": 130
     },
     "dataDependencies": {
       "title": "Data Dependencies",
+      "description": "Pre-requisite Data Packages on which this package requires in order to install.",
       "type": "object",
       "propertyOrder": 140
     }

--- a/data-package.json
+++ b/data-package.json
@@ -7,19 +7,33 @@
     "name": {
       "type": "string",
       "title": "Name",
-      "pattern": "^([a-z0-9\\.\\_\\-])+$"
+      "pattern": "^([a-z0-9\\.\\_\\-])+$",
+      "propertyOrder": 10
     },
     "title": {
       "title": "Title",
-      "type": "string"
+      "type": "string",
+      "propertyOrder": 20
     },
     "description": {
       "title": "Description",
-      "type": "string"
+      "type": "string",
+      "propertyOrder": 30
+    },
+    "homepage": {
+      "title": "Home Page",
+      "type": "string",
+      "propertyOrder": 40
+    },
+    "version": {
+      "title": "Version",
+      "type": "string",
+      "propertyOrder": 50
     },
     "licences": {
       "title": "Licenses",
       "type": "array",
+      "propertyOrder": 60,
       "items": {
         "type": "object",
         "properties": {
@@ -32,53 +46,15 @@
         ]
       }
     },
-    "homepage": {
-      "title": "Home Page",
-      "type": "string"
-    },
-    "version": {
-      "title": "Version",
-      "type": "string"
-    },
-    "sources": {
-      "title": "Sources",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "name": { "type": "string" },
-          "web": { "type": "string" },
-          "email": { "type": "string" }
-        },
-        "anyOf": [
-          { "title": "name required", "required": ["name"] },
-          { "title": "web required", "required": ["web"] },
-          { "title": "email required", "required": ["email"] }
-        ]
-      }
-    },
-    "keywords": {
-      "title": "Keywords",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "image": {
-      "title": "Image",
-      "type": "string"
-    },
-    "base": {
-      "title": "Base",
-      "type": "string"
-    },
     "author": {
       "title": "Author",
-      "type": "string"
+      "type": "string",
+      "propertyOrder": 70
     },
     "contributors": {
       "title": "Contributors",
       "type": "array",
+      "propertyOrder": 80,
       "items": {
         "type": "object",
         "properties": {
@@ -95,13 +71,10 @@
         "required": ["name"]
       }
     },
-    "dataDependencies": {
-      "title": "Data Dependencies",
-      "type": "object"
-    },
     "resources": {
       "title": "Resources",
       "type": "array",
+      "propertyOrder": 90,
       "minItems": 0,
       "items": {
         "type": "object",
@@ -186,6 +159,47 @@
           { "title": "path required", "required": ["path"] }
         ]
       }
+    },
+    "keywords": {
+      "title": "Keywords",
+      "type": "array",
+      "propertyOrder": 100,
+      "items": {
+        "type": "string"
+      }
+    },
+    "sources": {
+      "title": "Sources",
+      "type": "array",
+      "propertyOrder": 110,
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "web": { "type": "string" },
+          "email": { "type": "string" }
+        },
+        "anyOf": [
+          { "title": "name required", "required": ["name"] },
+          { "title": "web required", "required": ["web"] },
+          { "title": "email required", "required": ["email"] }
+        ]
+      }
+    },
+    "image": {
+      "title": "Image",
+      "type": "string",
+      "propertyOrder": 120
+    },
+    "base": {
+      "title": "Base",
+      "type": "string",
+      "propertyOrder": 130
+    },
+    "dataDependencies": {
+      "title": "Data Dependencies",
+      "type": "object",
+      "propertyOrder": 140
     }
   },
   "required": ["name"]

--- a/data-package.json
+++ b/data-package.json
@@ -64,10 +64,6 @@
         "type": "string"
       }
     },
-    "last_modified": {
-      "title": "Last Modified",
-      "type": "string"
-    },
     "image": {
       "title": "Image",
       "type": "string"
@@ -143,10 +139,6 @@
             "title": "Hash",
             "type": "string",
             "pattern": "^([^:]+:[a-fA-F0-9]+|[a-fA-F0-9]{32})$"
-          },
-          "modified": {
-            "title": "Modified",
-            "type": "string"
           },
           "schema": {
             "title": "Schema",

--- a/data-package.json
+++ b/data-package.json
@@ -86,7 +86,7 @@
         "required": ["name"]
       }
     },
-    "dependencies": {
+    "dataDependencies": {
       "type": "object"
     },
     "resources": {

--- a/data-package.json
+++ b/data-package.json
@@ -22,9 +22,6 @@
         ]
       }
     },
-    "datapackage_version": {
-      "type": "string"
-    },
     "title": {
       "type": "string"
     },

--- a/data-package.json
+++ b/data-package.json
@@ -62,9 +62,6 @@
     "image": {
       "type": "string"
     },
-    "bugs": {
-      "type": "string"
-    },
     "author": {
       "type": "string"
     },

--- a/data-package.json
+++ b/data-package.json
@@ -91,7 +91,7 @@
     },
     "resources": {
       "type": "array",
-      "minItems": 1,
+      "minItems": 0,
       "items": {
         "type": "object",
         "properties": {
@@ -168,5 +168,5 @@
       }
     }
   },
-  "required": ["name", "resources"]
+  "required": ["name"]
 }

--- a/data-package.json
+++ b/data-package.json
@@ -1,208 +1,208 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "title": "DataPackage",
-    "description": "JSON Schema for validating datapackage.json files",
-    "type": "object",
-    "properties": {
-        "name": {
-            "type": "string",
-            "pattern": "^([a-z0-9\\.\\_\\-])+$"
-        },
-        "licences": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "id": { "type": "string" },
-                    "url": { "type": "string" }
-                },
-                "anyOf": [
-                    { "title": "id required", "required": ["id"] },
-                    { "title": "url required", "required": ["url"] }
-                ]
-            }
-        },
-        "datapackage_version": {
-            "type": "string"
-        },
-        "title": {
-            "type": "string"
-        },
-        "description": {
-            "type": "string"
-        },
-        "homepage": {
-            "type": "string"
-        },
-        "version": {
-            "type": "string"
-        },
-        "sources": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "name": { "type": "string" },
-                    "web": { "type": "string" },
-                    "email": { "type": "string" }
-                },
-                "anyOf": [
-                        { "title": "name required", "required": ["name"] },
-                        { "title": "web required", "required": ["web"] },
-                        { "title": "email required", "required": ["email"] }
-                ]
-            }
-        },
-        "keywords": {
-            "type": "array",
-            "items": {
-                "type": "string"
-            }
-        },
-        "last_modified": {
-            "type": "string"
-        },
-        "image": {
-            "type": "string"
-        },
-        "bugs": {
-            "type": "string"
-        },
-        "maintainers": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "email": {
-                        "type": "string"
-                    },
-                    "web": {
-                        "type": "string"
-                    }
-                },
-                "required": ["name"]
-            }
-        },
-        "contributors": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "email": {
-                        "type": "string"
-                    },
-                    "web": {
-                        "type": "string"
-                    }
-                },
-                "required": ["name"]
-            }
-        },
-        "publisher": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "email": {
-                        "type": "string"
-                    },
-                    "web": {
-                        "type": "string"
-                    }
-                },
-                "required": ["name"]
-            }
-        },
-        "dependencies": {
-            "type": "object"
-        },
-        "resources": {
-            "type": "array",
-            "minItems": 1,
-            "items": {
-                "type": "object",
-                "properties": {
-                    "url": {
-                        "type": "string"
-                    },
-                    "path": {
-                        "type": "string"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "format": {
-                        "type": "string"
-                    },
-                    "mediatype": {
-                        "type": "string",
-                        "pattern": "^(.+)/(.+)$"
-                    },
-                    "encoding": {
-                        "type": "string"
-                    },
-                    "bytes": {
-                        "type": "integer"
-                    },
-                    "hash": {
-                        "type": "string",
-                        "pattern": "^([^:]+:[a-fA-F0-9]+|[a-fA-F0-9]{32})$"
-                    },
-                    "modified": {
-                        "type": "string"
-                    },
-                    "schema": {
-                        "type": "object"
-                    },
-                    "dialect": {
-                        "type": "object"
-                    },
-                    "sources": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "name": { "type": "string" },
-                                "web": { "type": "string" },
-                                "email": { "type": "string" }
-                            },
-                            "anyOf": [
-                                    { "title": "name required", "required": ["name"] },
-                                    { "title": "web required", "required": ["web"] },
-                                    { "title": "email required", "required": ["email"] }
-                            ]
-                        }
-                    },
-                    "licences": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "id": { "type": "string" },
-                                "url": { "type": "string" }
-                            },
-                            "anyOf": [
-                                { "title": "id required", "required": ["id"] },
-                                { "title": "url required", "required": ["url"] }
-                            ]
-                        }
-                    }
-                },
-                "anyOf": [
-                        { "title": "url required", "required": ["url"] },
-                        { "title": "path required", "required": ["path"] }
-                ]   
-            }
-        }
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "DataPackage",
+  "description": "JSON Schema for validating datapackage.json files",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "pattern": "^([a-z0-9\\.\\_\\-])+$"
     },
-    "required": ["name", "resources"]
+    "licences": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "url": { "type": "string" }
+        },
+        "anyOf": [
+          { "title": "id required", "required": ["id"] },
+          { "title": "url required", "required": ["url"] }
+        ]
+      }
+    },
+    "datapackage_version": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "homepage": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "web": { "type": "string" },
+          "email": { "type": "string" }
+        },
+        "anyOf": [
+          { "title": "name required", "required": ["name"] },
+          { "title": "web required", "required": ["web"] },
+          { "title": "email required", "required": ["email"] }
+        ]
+      }
+    },
+    "keywords": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "last_modified": {
+      "type": "string"
+    },
+    "image": {
+      "type": "string"
+    },
+    "bugs": {
+      "type": "string"
+    },
+    "maintainers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "web": {
+            "type": "string"
+          }
+        },
+        "required": ["name"]
+      }
+    },
+    "contributors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "web": {
+            "type": "string"
+          }
+        },
+        "required": ["name"]
+      }
+    },
+    "publisher": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "web": {
+            "type": "string"
+          }
+        },
+        "required": ["name"]
+      }
+    },
+    "dependencies": {
+      "type": "object"
+    },
+    "resources": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "format": {
+            "type": "string"
+          },
+          "mediatype": {
+            "type": "string",
+            "pattern": "^(.+)/(.+)$"
+          },
+          "encoding": {
+            "type": "string"
+          },
+          "bytes": {
+            "type": "integer"
+          },
+          "hash": {
+            "type": "string",
+            "pattern": "^([^:]+:[a-fA-F0-9]+|[a-fA-F0-9]{32})$"
+          },
+          "modified": {
+            "type": "string"
+          },
+          "schema": {
+            "type": "object"
+          },
+          "dialect": {
+            "type": "object"
+          },
+          "sources": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" },
+                "web": { "type": "string" },
+                "email": { "type": "string" }
+              },
+              "anyOf": [
+                { "title": "name required", "required": ["name"] },
+                { "title": "web required", "required": ["web"] },
+                { "title": "email required", "required": ["email"] }
+              ]
+            }
+          },
+          "licences": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "string" },
+                "url": { "type": "string" }
+              },
+              "anyOf": [
+                { "title": "id required", "required": ["id"] },
+                { "title": "url required", "required": ["url"] }
+              ]
+            }
+          }
+        },
+        "anyOf": [
+          { "title": "url required", "required": ["url"] },
+          { "title": "path required", "required": ["path"] }
+        ]
+      }
+    }
+  },
+  "required": ["name", "resources"]
 }

--- a/data-package.json
+++ b/data-package.json
@@ -65,43 +65,10 @@
     "bugs": {
       "type": "string"
     },
-    "maintainers": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "email": {
-            "type": "string"
-          },
-          "web": {
-            "type": "string"
-          }
-        },
-        "required": ["name"]
-      }
+    "author": {
+      "type": "string"
     },
     "contributors": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "email": {
-            "type": "string"
-          },
-          "web": {
-            "type": "string"
-          }
-        },
-        "required": ["name"]
-      }
-    },
-    "publisher": {
       "type": "array",
       "items": {
         "type": "object",

--- a/data-package.json
+++ b/data-package.json
@@ -6,15 +6,19 @@
   "properties": {
     "name": {
       "type": "string",
+      "title": "Name",
       "pattern": "^([a-z0-9\\.\\_\\-])+$"
     },
     "title": {
+      "title": "Title",
       "type": "string"
     },
     "description": {
+      "title": "Description",
       "type": "string"
     },
     "licences": {
+      "title": "Licenses",
       "type": "array",
       "items": {
         "type": "object",
@@ -29,12 +33,15 @@
       }
     },
     "homepage": {
+      "title": "Home Page",
       "type": "string"
     },
     "version": {
+      "title": "Version",
       "type": "string"
     },
     "sources": {
+      "title": "Sources",
       "type": "array",
       "items": {
         "type": "object",
@@ -51,24 +58,30 @@
       }
     },
     "keywords": {
+      "title": "Keywords",
       "type": "array",
       "items": {
         "type": "string"
       }
     },
     "last_modified": {
+      "title": "Last Modified",
       "type": "string"
     },
     "image": {
+      "title": "Image",
       "type": "string"
     },
     "base": {
+      "title": "Base",
       "type": "string"
     },
     "author": {
+      "title": "Author",
       "type": "string"
     },
     "contributors": {
+      "title": "Contributors",
       "type": "array",
       "items": {
         "type": "object",
@@ -87,50 +100,64 @@
       }
     },
     "dataDependencies": {
+      "title": "Data Dependencies",
       "type": "object"
     },
     "resources": {
+      "title": "Resources",
       "type": "array",
       "minItems": 0,
       "items": {
         "type": "object",
         "properties": {
           "url": {
+            "title": "URL",
             "type": "string"
           },
           "path": {
+            "title": "Path",
             "type": "string"
           },
           "name": {
+            "title": "Name",
             "type": "string"
           },
           "format": {
+            "title": "Format",
             "type": "string"
           },
           "mediatype": {
+            "title": "Media Type",
             "type": "string",
             "pattern": "^(.+)/(.+)$"
           },
           "encoding": {
+            "title": "Encoding",
             "type": "string"
           },
           "bytes": {
+            "title": "Bytes",
             "type": "integer"
           },
           "hash": {
+            "title": "Hash",
             "type": "string",
             "pattern": "^([^:]+:[a-fA-F0-9]+|[a-fA-F0-9]{32})$"
           },
           "modified": {
+            "title": "Modified",
             "type": "string"
           },
           "schema": {
+            "title": "Schema",
             "type": "object"
           },
           "dialect": {
+            "title": "Dialect",
             "type": "object"
           },
           "sources": {
+            "title": "Sources",
             "type": "array",
             "items": {
               "type": "object",
@@ -147,6 +174,7 @@
             }
           },
           "licences": {
+            "title": "Licenses",
             "type": "array",
             "items": {
               "type": "object",


### PR DESCRIPTION
* Cleans up the schema to reflect the current state of the Data Package spec
* Adds meta data to the schema which can be used in libraries that work with Data Package via the JSON Schema. Example: field ordering when generating a form with https://github.com/jdorn/json-editor. 