### PR TITLE
feature/tabular-data-package

### DIFF
--- a/tabular-data-package.json
+++ b/tabular-data-package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "DataPackage",
-  "description": "JSON Schema for validating datapackage.json files",
+  "title": "Tabular Data Package",
+  "description": "JSON Schema for validating datapackage.json files according to the Tabular Data Package specification. Tabular Data Package is a Profile of the Data Package specification, extending and specializing it for the specific case of tabular data.",
   "type": "object",
   "properties": {
     "name": {
@@ -85,7 +85,7 @@
       "description": "The data resources that this package describes.",
       "type": "array",
       "propertyOrder": 90,
-      "minItems": 0,
+      "minItems": 1,
       "items": {
         "type": "object",
         "properties": {
@@ -189,8 +189,8 @@
           }
         },
         "anyOf": [
-          { "title": "url required", "required": ["url"] },
-          { "title": "path required", "required": ["path"] }
+          { "title": "url required", "required": ["name", "schema", "url"] },
+          { "title": "path required", "required": ["name", "schema", "path"] }
         ]
       }
     },
@@ -241,5 +241,5 @@
       "propertyOrder": 140
     }
   },
-  "required": ["name"]
+  "required": ["name", "resources"]
 }

--- a/tabular-data-package.json
+++ b/tabular-data-package.json
@@ -1,0 +1,245 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "DataPackage",
+  "description": "JSON Schema for validating datapackage.json files",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "title": "Name",
+      "description": "A lower-case string with only alphanumeric characters along with '.', '_' or '-' characters.",
+      "pattern": "^([a-z0-9\\.\\_\\-])+$",
+      "propertyOrder": 10
+    },
+    "title": {
+      "title": "Title",
+      "description": "A human-readable title for this package.",
+      "type": "string",
+      "propertyOrder": 20
+    },
+    "description": {
+      "title": "Description",
+      "description": "A text description of the package.",
+      "type": "string",
+      "propertyOrder": 30,
+      "format": "textarea"
+    },
+    "homepage": {
+      "title": "Home Page",
+      "description": "The URL for this data package's website.",
+      "type": "string",
+      "propertyOrder": 40
+    },
+    "version": {
+      "title": "Version",
+      "description": "A semantic versioning string for this package.",
+      "type": "string",
+      "propertyOrder": 50
+    },
+    "licences": {
+      "title": "Licenses",
+      "description": "The license(s) under which this package is published.",
+      "type": "array",
+      "propertyOrder": 60,
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "url": { "type": "string" }
+        },
+        "anyOf": [
+          { "title": "id required", "required": ["id"] },
+          { "title": "url required", "required": ["url"] }
+        ]
+      }
+    },
+    "author": {
+      "title": "Author",
+      "description": "The main contributor to this package.",
+      "type": "string",
+      "propertyOrder": 70
+    },
+    "contributors": {
+      "title": "Contributors",
+      "description": "The contributors to this package.",
+      "type": "array",
+      "propertyOrder": 80,
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "web": {
+            "type": "string"
+          }
+        },
+        "required": ["name"]
+      }
+    },
+    "resources": {
+      "title": "Resources",
+      "description": "The data resources that this package describes.",
+      "type": "array",
+      "propertyOrder": 90,
+      "minItems": 0,
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "title": "Name",
+            "description": "A lower-case string with only alphanumeric characters along with '.', '_' or '-' characters.",
+            "type": "string",
+            "propertyOrder": 10
+          },
+          "url": {
+            "title": "URL",
+            "description": "The URL for this resource.",
+            "type": "string",
+            "propertyOrder": 20
+          },
+          "path": {
+            "title": "Path",
+            "description": "The relative path to this resource.",
+            "type": "string",
+            "propertyOrder": 30
+          },
+          "format": {
+            "title": "Format",
+            "description": "The file format of this resource.",
+            "type": "string",
+            "propertyOrder": 40
+          },
+          "mediatype": {
+            "title": "Media Type",
+            "description": "The media type of this resource.",
+            "type": "string",
+            "propertyOrder": 50,
+            "pattern": "^(.+)/(.+)$"
+          },
+          "encoding": {
+            "title": "Encoding",
+            "description": "The file encoding of this resource.",
+            "type": "string",
+            "propertyOrder": 60
+          },
+          "bytes": {
+            "title": "Bytes",
+            "description": "The size of this resource in bytes.",
+            "type": "integer",
+            "propertyOrder": 70
+          },
+          "hash": {
+            "title": "Hash",
+            "type": "string",
+            "description": "The MD5 hash of this resource. Other hash algorithms can be used by prefxing the hash value with the algorithm name in lowercase, followed by a colon.",
+            "propertyOrder": 80,
+            "pattern": "^([^:]+:[a-fA-F0-9]+|[a-fA-F0-9]{32})$"
+          },
+          "schema": {
+            "title": "Schema",
+            "description": "The schema of this resource.",
+            "type": "object",
+            "propertyOrder": 90
+          },
+          "dialect": {
+            "title": "Dialect",
+            "description": "The dialect of this resource file type.",
+            "type": "object",
+            "propertyOrder": 100
+          },
+          "sources": {
+            "title": "Sources",
+            "description": "The raw sources for this resource.",
+            "type": "array",
+            "propertyOrder": 110,
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" },
+                "web": { "type": "string" },
+                "email": { "type": "string" }
+              },
+              "anyOf": [
+                { "title": "name required", "required": ["name"] },
+                { "title": "web required", "required": ["web"] },
+                { "title": "email required", "required": ["email"] }
+              ]
+            }
+          },
+          "licences": {
+            "title": "Licenses",
+            "description": "The license(s) under which this resource is released.",
+            "type": "array",
+            "propertyOrder": 120,
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "string" },
+                "url": { "type": "string" }
+              },
+              "anyOf": [
+                { "title": "id required", "required": ["id"] },
+                { "title": "url required", "required": ["url"] }
+              ]
+            }
+          }
+        },
+        "anyOf": [
+          { "title": "url required", "required": ["url"] },
+          { "title": "path required", "required": ["path"] }
+        ]
+      }
+    },
+    "keywords": {
+      "title": "Keywords",
+      "description": "A list of keywords that describe this package.",
+      "type": "array",
+      "propertyOrder": 100,
+      "items": {
+        "type": "string"
+      }
+    },
+    "sources": {
+      "title": "Sources",
+      "description": "The raw sources for this package.",
+      "type": "array",
+      "propertyOrder": 110,
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "web": { "type": "string" },
+          "email": { "type": "string" }
+        },
+        "anyOf": [
+          { "title": "name required", "required": ["name"] },
+          { "title": "web required", "required": ["web"] },
+          { "title": "email required", "required": ["email"] }
+        ]
+      }
+    },
+    "image": {
+      "title": "Image",
+      "description": "A image to represent this package.",
+      "type": "string",
+      "propertyOrder": 120
+    },
+    "base": {
+      "title": "Base",
+      "description": "A base URI used to resolve resources that specify relative paths.",
+      "type": "string",
+      "propertyOrder": 130
+    },
+    "dataDependencies": {
+      "title": "Data Dependencies",
+      "description": "Pre-requisite Data Packages on which this package requires in order to install.",
+      "type": "object",
+      "propertyOrder": 140
+    }
+  },
+  "required": ["name"]
+}


### PR DESCRIPTION
Introduces a schema for tabular data package.

* Copies the data package schema, and makes small changes for the TDP spec

See this commit for the diff between the two: https://github.com/pwalsh/schemas/commit/c0ab883bfbb31e66c94f84d67daeb3a69e4f73a3

Notes:

We can do better by reusing components of the schemas using `$ref`, and therefore prevent much duplication across DP, TDP, and other Profiles we'll add in the future. 

I'm not bothering with that now - if this is accepted, another pull request can deal with DRY issues.