### PR TITLE
Fix name patterns (regular expression) for packages and resources

### DIFF
--- a/data-package.json
+++ b/data-package.json
@@ -8,7 +8,7 @@
       "title": "Name",
       "description": "A lower-case string with only alphanumeric characters along with '.', '_' or '-' characters.",
       "type": "string",
-      "pattern": "^([a-z0-9\\.\\_\\-])+$",
+      "pattern": "^([a-z0-9._-])+$",
       "propertyOrder": 10
     },
     "title": {
@@ -93,7 +93,7 @@
             "title": "Name",
             "description": "A lower-case string with only alphanumeric characters along with '.', '_' or '-' characters.",
             "type": "string",
-            "pattern": "^([a-z0-9\\.\\_\\-])+$",
+            "pattern": "^([a-z0-9._-])+$",
             "propertyOrder": 10
           },
           "title": {

--- a/tabular-data-package.json
+++ b/tabular-data-package.json
@@ -8,7 +8,7 @@
       "type": "string",
       "title": "Name",
       "description": "A lower-case string with only alphanumeric characters along with '.', '_' or '-' characters.",
-      "pattern": "^([a-z0-9\\.\\_\\-])+$",
+      "pattern": "^([a-z0-9._-])+$",
       "propertyOrder": 10
     },
     "title": {
@@ -93,7 +93,7 @@
             "title": "Name",
             "description": "A lower-case string with only alphanumeric characters along with '.', '_' or '-' characters.",
             "type": "string",
-            "pattern": "^([a-z0-9\\.\\_\\-])+$",
+            "pattern": "^([a-z0-9._-])+$",
             "propertyOrder": 10
           },
           "title": {


### PR DESCRIPTION
Characters like for example the single character match '.' do not
have to be escaped in bracket expression because within the scope
of bracket expressions they match the literal characters. There are
also unknown "escape sequences" in the bracket expression like for
example ``\_``. Therefore removing any escapes of characters in bracket
expressions for names of packages and resources in both data
package schema and tabular data package schema.