### PR TITLE
Update data package schema to conform to version 1.0.0-beta.14

### DIFF
--- a/data-package.json
+++ b/data-package.json
@@ -3,6 +3,27 @@
   "title": "DataPackage",
   "description": "DataPackage is a format and specification for convenient delivery, installation and management of data. This is the base profile for DataPackage.",
   "type": "object",
+  "definitions": {
+    "license": {
+      "title": "License",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": { "type": "string" },
+            "url": { "type": "string" }
+          },
+          "anyOf": [
+            { "title": "type required", "required": ["type"] },
+            { "title": "url required", "required": ["url"] }
+          ]
+        }
+      ]
+    }
+  },
   "properties": {
     "name": {
       "title": "Name",
@@ -36,22 +57,10 @@
       "type": "string",
       "propertyOrder": 50
     },
-    "licences": {
-      "title": "Licenses",
-      "description": "The license(s) under which this package is published.",
-      "type": "array",
-      "propertyOrder": 60,
-      "items": {
-        "type": "object",
-        "properties": {
-          "id": { "type": "string" },
-          "url": { "type": "string" }
-        },
-        "anyOf": [
-          { "title": "id required", "required": ["id"] },
-          { "title": "url required", "required": ["url"] }
-        ]
-      }
+    "license": {
+      "$ref": "#/definitions/license",
+      "description": "The license under which this package is published",
+      "propertyOrder": 60
     },
     "author": {
       "title": "Author",
@@ -185,22 +194,10 @@
               ]
             }
           },
-          "licences": {
-            "title": "Licenses",
-            "description": "The license(s) under which this resource is released.",
-            "type": "array",
-            "propertyOrder": 140,
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": { "type": "string" },
-                "url": { "type": "string" }
-              },
-              "anyOf": [
-                { "title": "id required", "required": ["id"] },
-                { "title": "url required", "required": ["url"] }
-              ]
-            }
+          "licence": {
+            "$ref": "#/definitions/license",
+            "description": "The license under which the resource is published.",
+            "propertyOrder": 140
           }
         },
         "anyOf": [


### PR DESCRIPTION
Version 1.0.0-beta.14 dropped 'licenses' in favour of 'license' for
both data package and resources. This updates both by putting
license in a subschema (definition) and referencing it from the
data package license and resource license properties. Putting it
in definitions also allows other schemas to more clearly reference
it.