### PR TITLE
Add fiscal data package schema

### DIFF
--- a/fiscal-data-package.json
+++ b/fiscal-data-package.json
@@ -1,0 +1,122 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Fiscal Data Package",
+    "description": "Fiscal Data Package is a lightweight and user-oriented format for publishing and consuming fiscal data. Fiscal data packages are made of simple and universal components. They can be produced from ordinary spreadsheet software and used in any environment.",
+    "type": "object",
+    "properties": {
+	"countryCode" : {
+	    "title": "ISO 3166-1 Alpha-2 Country code",
+	    "description": "A valid 2 -digit ISO country code (ISO 3166-1 alpha-2) ,or, an array of valid ISO codes (if this relates to multiple countries). This field is for listing the country of countries associated to this data. For example, if this the budget for country then you would put that country’s ISO code.",
+	    "type": "string",
+	    "pattern": "^[A-Z]{2}$"
+	},
+	"granularity": {
+	    "title": "Granularity of resources",
+	    "description": "A keyword that represents the type of spend data, eiter aggregated or transactional",
+	    "type": "string",
+	    "enum": ["aggregated", "transactional"]
+	},
+	"direction": {
+	    "title": "Direction of the spending",
+	    "description": "A keyword that represents the direction of the spend, either expenditure or revenue.",
+	    "type": "string",
+	    "enum": ["expenditure", "revenue"]
+	},
+	"status": {
+	    "title": "Budget status",
+	    "description": "A keyword that represents the status of the data, can be proposed for a budget proposal, approved for an approved budget, adjusted for modified budget or executed for the enacted budget",
+	    "type": "string",
+	    "enum": ["proposed", "approved", "adjusted", "executed"]
+	},
+	"fiscalPeriod": {
+	    "title": "Fiscal period for the budget",
+	    "description": "The fiscal period of the dataset, represented in the ISO 8601 time interval convention, that is two ISO dates separated by a solidus (/), e.g. 1982-04-22/1983-04-21",
+	    "type": "string",
+	    "pattern": "^\\d{4}-(0?[1-9]|1[012])-(0?[1-9]|[12]\\d|3[01])/\\d{4}-(0?[1-9]|1[012])-(0?[1-9]|[12]\\d|3[01])$"
+	},
+	"mapping": {
+	    "title": "",
+	    "description": "",
+	    "type": "object",
+	    "properties": {
+		"measures": {
+		    "title": "",
+		    "description": "",
+		    "type": "object",
+		    "patternProperties": {
+			"^\\w*$": {
+			    "type": "object",
+			    "properties": {
+				"source": {
+				    "type": "string"
+				},
+				"currency": {
+				    "type": "string"
+				},
+				"factor": {
+				    "type": "number"
+				}
+			    },
+			    "required": ["source", "currency"]
+			}
+		    }
+		}
+	    },
+	    "patternProperties": {
+		"^(?!measures)\\w+$": {
+		    "type": "object",
+		    "properties": {
+			"dimensionType": {
+			    "type": "string",
+			    "enum": ["datetime", "entity", "classification", "project"]
+			},
+			"fields": {			    
+			    "type": "object",
+			    "patternProperties": {
+				"^\\w*$": {
+				    "type": "object",
+				    "properties": {
+					"source": {
+					    "type": "string"
+					}
+				    },
+				    "anyOf": [
+					{
+                                            "properties": {
+                                                "primaryKey":  {
+                                                    "type": "boolean"
+					        }
+                                            }
+                                        },
+					{
+                                            "properties": {
+                                                "primaryKey":  {
+                                                    "type": "string"
+					        }
+                                            }
+                                        }
+                                    ]
+				}
+			    }
+			}
+		    }
+		}
+	    }
+	},
+	"title": { "$ref": "https://raw.githubusercontent.com/dataprotocols/schemas/master/data-package.json#/properties/title" },
+	"name": { "$ref": "https://raw.githubusercontent.com/dataprotocols/schemas/master/data-package.json#/properties/name" },
+	"description": { "$ref": "https://raw.githubusercontent.com/dataprotocols/schemas/master/data-package.json#/properties/description" },
+	"license": { "$ref": "https://raw.githubusercontent.com/dataprotocols/schemas/master/data-package.json#/properties/license" },
+	"homepage": { "$ref": "https://raw.githubusercontent.com/dataprotocols/schemas/master/data-package.json#/properties/homepage" },
+	"version": { "$ref": "https://raw.githubusercontent.com/dataprotocols/schemas/master/data-package.json#/properties/version" },
+	"author": { "$ref": "https://raw.githubusercontent.com/dataprotocols/schemas/master/data-package.json#/properties/author" },
+	"contributors": { "$ref": "https://raw.githubusercontent.com/dataprotocols/schemas/master/data-package.json#/properties/contributors" },
+	"resources": { "$ref": "https://raw.githubusercontent.com/dataprotocols/schemas/master/tabular-data-package.json#/properties/resources" },
+   	"keywords": { "$ref": "https://raw.githubusercontent.com/dataprotocols/schemas/master/data-package.json#/properties/keywords" },
+	"sources": { "$ref": "https://raw.githubusercontent.com/dataprotocols/schemas/master/data-package.json#/properties/sources" },
+	"image": { "$ref": "https://raw.githubusercontent.com/dataprotocols/schemas/master/data-package.json#/properties/image" },
+	"base": { "$ref": "https://raw.githubusercontent.com/dataprotocols/schemas/master/data-package.json#/properties/base" },
+	"dataDependencies": { "$ref": "https://raw.githubusercontent.com/dataprotocols/schemas/master/data-package.json#/properties/dataDependencies" }
+    },
+    "required": ["name", "resources", "mapping"]
+}


### PR DESCRIPTION
The fiscal data package schema relies heavily on $ref which for now
only points to raw github uris but should optimally be a nicer
domain, e.g. schemas.dataprotocols.org

The schema is compatible with version 0.3.0-alpha2 of fiscal data
package and tries as hard as possible to tackle the mapping
property which allows random dimension names and measures names
which require some patternProperties hacking. Field primary key for
dimensions is also not properly addressed in the schema because it
has to be present in at least one field, but not in all. That's
very difficult to address in a schema.

There are also inconsistencies in the spec, e.g. around dimension
types which are listed in an example and in a list of possible
values and the two lists are inconsistent. We go with the spec
list rather than the listed options in the example in the spec.

There are some pull requests open on the fiscal data package spec
which will require changes to this schema, but as is, it's usable
for the most part.