### PR TITLE
Add 'enum' field constraint

### DIFF
--- a/json-table-schema.json
+++ b/json-table-schema.json
@@ -54,6 +54,11 @@
                                     {"type": "string"},
                                     {"type": "number"}
                                 ]
+                            },
+                            "enum": {
+                                "type": "array",
+                                "minItems": 1,
+                                "uniqueItems": true
                             }
                         }
                     }


### PR DESCRIPTION
Not sure if there is a way of specifying that the type of the enum field constraint must match the type of the 'type' field definition in json schema.