### PR TITLE
Added option for strings for contributors or schema

### DIFF
--- a/data-package.json
+++ b/data-package.json
@@ -77,19 +77,26 @@
         "hidden": true
       },
       "items": {
-        "type": "object",
-        "properties": {
-          "name": {
+        "oneOf": [
+          {
             "type": "string"
           },
-          "email": {
-            "type": "string"
-          },
-          "web": {
-            "type": "string"
+          {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string"
+              },
+              "web": {
+                "type": "string"
+              }
+            },
+            "required": ["name"]
           }
-        },
-        "required": ["name"]
+        ]
       }
     },
     "resources": {
@@ -124,7 +131,14 @@
           "schema": {
             "title": "Schema",
             "description": "The schema of this resource.",
-            "type": "object",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object"
+              }
+            ],
             "propertyOrder": 40
           },
 


### PR DESCRIPTION
Trying to validate my schema, the spec says that `contributors` can EITHER be a string or an object.  The same applies to `schema`.

It's possible that my reading of the spec is incorrect, but this pull requests causes the validation to no longer fail against my spec located at https://github.com/cmoa/collection/blob/master/datapackage.json.