### PR TITLE
Fix Tabular Data Package's "license" field

### DIFF
--- a/data-package.json
+++ b/data-package.json
@@ -214,7 +214,7 @@
               ]
             }
           },
-          "licence": {
+          "license": {
             "$ref": "#/definitions/license",
             "description": "The license under which the resource is published.",
             "propertyOrder": 140

--- a/tabular-data-package.json
+++ b/tabular-data-package.json
@@ -19,6 +19,25 @@
           "required": ["name"]
         }
       ]
+    },
+    "license": {
+      "title": "License",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": { "type": "string" },
+            "url": { "type": "string" }
+          },
+          "anyOf": [
+            { "title": "type required", "required": ["type"] },
+            { "title": "url required", "required": ["url"] }
+          ]
+        }
+      ]
     }
   },
   "properties": {
@@ -54,22 +73,10 @@
       "type": "string",
       "propertyOrder": 50
     },
-    "licences": {
-      "title": "Licenses",
-      "description": "The license(s) under which this package is published.",
-      "type": "array",
-      "propertyOrder": 60,
-      "items": {
-        "type": "object",
-        "properties": {
-          "id": { "type": "string" },
-          "url": { "type": "string" }
-        },
-        "anyOf": [
-          { "title": "id required", "required": ["id"] },
-          { "title": "url required", "required": ["url"] }
-        ]
-      }
+    "license": {
+      "$ref": "#/definitions/license",
+      "description": "The license under which this package is published.",
+      "propertyOrder": 60
     },
     "author": {
       "$ref": "#/definitions/contributor",
@@ -191,22 +198,10 @@
               ]
             }
           },
-          "licences": {
-            "title": "Licenses",
-            "description": "The license(s) under which this resource is released.",
-            "type": "array",
-            "propertyOrder": 140,
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": { "type": "string" },
-                "url": { "type": "string" }
-              },
-              "anyOf": [
-                { "title": "id required", "required": ["id"] },
-                { "title": "url required", "required": ["url"] }
-              ]
-            }
+          "license": {
+            "$ref": "#/definitions/license",
+            "description": "The license under which the resource is published.",
+            "propertyOrder": 140
           }
         },
         "anyOf": [


### PR DESCRIPTION
It used to be "licenses", but was changed on Data Package version 1.0.0-beta.14.